### PR TITLE
Mockingbird: fix paths and document the checkpoints.

### DIFF
--- a/systems/mockingbird-n2/README.md
+++ b/systems/mockingbird-n2/README.md
@@ -5,3 +5,9 @@ Only the results for 10% data sparsity are provided.
 Cognate Neighbors model, where a single model is constructed for each language
 group
 ([implementation](https://github.com/google-research/google-research/tree/master/cognate_inpaint_neighbors)).
+
+Caveat: Please note, different models are trained for different number of steps
+with no meaningful stopping criteria. After some reasonably large number of
+steps the training is stopped and the inference is performed using the latest
+checkpoint. The checkpoint is documented under the inference section in the
+respective `README.md` files for each language group.

--- a/systems/mockingbird-n2/surprise/bantubvd/README.md
+++ b/systems/mockingbird-n2/surprise/bantubvd/README.md
@@ -9,13 +9,13 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/bantubvd_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/bantubvd_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --logdir /tmp/logdir/
 ```
 
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bantubvd_test.tfrecords --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/bantubvd_test.tfrecords --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00037150`.

--- a/systems/mockingbird-n2/surprise/bantubvd/README.md
+++ b/systems/mockingbird-n2/surprise/bantubvd/README.md
@@ -17,3 +17,5 @@ python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_m
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bantubvd_test.tfrecords --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00037150`.

--- a/systems/mockingbird-n2/surprise/bantubvd/README.md
+++ b/systems/mockingbird-n2/surprise/bantubvd/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bantubvd --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bantubvd --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
 ```shell
-python neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/bantubvd_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/bantubvd_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/bantubvd_test.tfrecords --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bantubvd_test.tfrecords --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/bantubvd/README.md
+++ b/systems/mockingbird-n2/surprise/bantubvd/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bantubvd --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bantubvd --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
 ## Training

--- a/systems/mockingbird-n2/surprise/bantubvd/README.md
+++ b/systems/mockingbird-n2/surprise/bantubvd/README.md
@@ -1,10 +1,18 @@
+# `bantubvd`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bantubvd --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
+## Training
+
 ```shell
 python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/bantubvd_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/bantubvd_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --logdir /tmp/logdir/
 ```
+
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bantubvd_test.tfrecords --input_symbols /tmp/tmp/bantubvd.syms --output_symbols /tmp/tmp/bantubvd.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=11 --max_spelling_len=3 --batch_size 1

--- a/systems/mockingbird-n2/surprise/beidazihui/README.md
+++ b/systems/mockingbird-n2/surprise/beidazihui/README.md
@@ -15,3 +15,5 @@ python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_m
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/beidazihui_test.tfrecords --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00044964`.

--- a/systems/mockingbird-n2/surprise/beidazihui/README.md
+++ b/systems/mockingbird-n2/surprise/beidazihui/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group beidazihui --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group beidazihui --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 ## Training
 

--- a/systems/mockingbird-n2/surprise/beidazihui/README.md
+++ b/systems/mockingbird-n2/surprise/beidazihui/README.md
@@ -8,12 +8,12 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/beidazihui_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --learning_rate=0.001 --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/beidazihui_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --learning_rate=0.001 --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --logdir /tmp/logdir/
 ```
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/beidazihui_test.tfrecords --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/beidazihui_test.tfrecords --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00044964`.

--- a/systems/mockingbird-n2/surprise/beidazihui/README.md
+++ b/systems/mockingbird-n2/surprise/beidazihui/README.md
@@ -1,10 +1,16 @@
+# `beidazihui`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group beidazihui --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
+## Training
 
 ```shell
 python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/beidazihui_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --learning_rate=0.001 --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --logdir /tmp/logdir/
 ```
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/beidazihui_test.tfrecords --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --batch_size 1

--- a/systems/mockingbird-n2/surprise/beidazihui/README.md
+++ b/systems/mockingbird-n2/surprise/beidazihui/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group beidazihui --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group beidazihui --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
 ```shell
-python neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/beidazihui_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --learning_rate=0.001 --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/beidazihui_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/beidazihui_test.tfrecords --learning_rate=0.001 --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/beidazihui_test.tfrecords --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/beidazihui_test.tfrecords --input_symbols /tmp/tmp/beidazihui.syms --output_symbols /tmp/tmp/beidazihui.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=14 --max_pronunciation_len=6 --max_spelling_len=16 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
+++ b/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
@@ -1,10 +1,18 @@
+# `birchallchapacuran`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group birchallchapacuran --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
+## Training
+
 ```shell
 python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/birchallchapacuran_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --logdir /tmp/logdir/
 ```
+
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --batch_size 1

--- a/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
+++ b/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
@@ -17,3 +17,5 @@ python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_m
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00019687`.

--- a/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
+++ b/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group birchallchapacuran --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group birchallchapacuran --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
 ```shell
-python neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/birchallchapacuran_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/birchallchapacuran_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
+++ b/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group birchallchapacuran --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group birchallchapacuran --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
 ## Training

--- a/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
+++ b/systems/mockingbird-n2/surprise/birchallchapacuran/README.md
@@ -9,13 +9,13 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/birchallchapacuran_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/birchallchapacuran_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --logdir /tmp/logdir/
 ```
 
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/birchallchapacuran_test.tfrecords --input_symbols /tmp/tmp/birchallchapacuran.syms --output_symbols /tmp/tmp/birchallchapacuran.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=15 --max_spelling_len=9 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00019687`.

--- a/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
+++ b/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
@@ -9,13 +9,13 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/bodtkhobwa_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/bodtkhobwa_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --logdir /tmp/logdir/
 ```
 
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00064124`.

--- a/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
+++ b/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
@@ -17,3 +17,5 @@ python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_m
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00064124`.

--- a/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
+++ b/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bodtkhobwa --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bodtkhobwa --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
 ```shell
-python neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/bodtkhobwa_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/bodtkhobwa_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
+++ b/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bodtkhobwa --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bodtkhobwa --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
 ## Training

--- a/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
+++ b/systems/mockingbird-n2/surprise/bodtkhobwa/README.md
@@ -1,10 +1,18 @@
+# `bodtkhobwa`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bodtkhobwa --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 50
 ```
 
+## Training
+
 ```shell
 python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/bodtkhobwa_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --logdir /tmp/logdir/
 ```
+
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bodtkhobwa_test.tfrecords --input_symbols /tmp/tmp/bodtkhobwa.syms --output_symbols /tmp/tmp/bodtkhobwa.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=6 --max_spelling_len=9 --batch_size 1

--- a/systems/mockingbird-n2/surprise/bremerberta/README.md
+++ b/systems/mockingbird-n2/surprise/bremerberta/README.md
@@ -17,3 +17,5 @@ python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_m
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bremerberta_test.tfrecords --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00036461`.

--- a/systems/mockingbird-n2/surprise/bremerberta/README.md
+++ b/systems/mockingbird-n2/surprise/bremerberta/README.md
@@ -9,13 +9,13 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/bremerberta_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --learning_rate=0.001 --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/bremerberta_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --learning_rate=0.001 --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --logdir /tmp/logdir/
 ```
 
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bremerberta_test.tfrecords --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/bremerberta_test.tfrecords --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00036461`.

--- a/systems/mockingbird-n2/surprise/bremerberta/README.md
+++ b/systems/mockingbird-n2/surprise/bremerberta/README.md
@@ -1,10 +1,18 @@
+# `bremerberta`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bremerberta --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
+## Training
+
 ```shell
 python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/bremerberta_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --learning_rate=0.001 --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --logdir /tmp/logdir/
 ```
+
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bremerberta_test.tfrecords --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --batch_size 1

--- a/systems/mockingbird-n2/surprise/bremerberta/README.md
+++ b/systems/mockingbird-n2/surprise/bremerberta/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bremerberta --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bremerberta --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ```shell
-python neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/bremerberta_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --learning_rate=0.001 --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/bremerberta_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/bremerberta_test.tfrecords --learning_rate=0.001 --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/bremerberta_test.tfrecords --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/bremerberta_test.tfrecords --input_symbols /tmp/tmp/bremerberta.syms --output_symbols /tmp/tmp/bremerberta.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=3 --max_pronunciation_len=12 --max_spelling_len=14 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/bremerberta/README.md
+++ b/systems/mockingbird-n2/surprise/bremerberta/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bremerberta --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group bremerberta --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ## Training

--- a/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
+++ b/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
@@ -1,10 +1,18 @@
+# `deepadungpalaung`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group deepadungpalaung --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
+## Training
+
 ```shell
 ython neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/deepadungpalaung_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --learning_rate=0.001 --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --logdir /tmp/logdir/
 ```
+
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --batch_size 1

--- a/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
+++ b/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
@@ -17,3 +17,5 @@ ython neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_mo
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00025363`.

--- a/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
+++ b/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
@@ -9,13 +9,13 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-ython neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/deepadungpalaung_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --learning_rate=0.001 --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --logdir /tmp/logdir/
+ython neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/deepadungpalaung_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --learning_rate=0.001 --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --logdir /tmp/logdir/
 ```
 
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00025363`.

--- a/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
+++ b/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group deepadungpalaung --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group deepadungpalaung --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ## Training

--- a/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
+++ b/systems/mockingbird-n2/surprise/deepadungpalaung/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group deepadungpalaung --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group deepadungpalaung --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ```shell
-ython neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/deepadungpalaung_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --learning_rate=0.001 --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --logdir /tmp/logdir/
+ython neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/deepadungpalaung_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --learning_rate=0.001 --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/deepadungpalaung_test.tfrecords --input_symbols /tmp/tmp/deepadungpalaung.syms --output_symbols /tmp/tmp/deepadungpalaung.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=15 --max_pronunciation_len=8 --max_spelling_len=14 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/hillburmish/README.md
+++ b/systems/mockingbird-n2/surprise/hillburmish/README.md
@@ -17,3 +17,5 @@ python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_m
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/hillburmish_test.tfrecords --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00038142`.

--- a/systems/mockingbird-n2/surprise/hillburmish/README.md
+++ b/systems/mockingbird-n2/surprise/hillburmish/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group hillburmish --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group hillburmish --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ## Training

--- a/systems/mockingbird-n2/surprise/hillburmish/README.md
+++ b/systems/mockingbird-n2/surprise/hillburmish/README.md
@@ -9,13 +9,13 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/hillburmish_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --learning_rate=0.001 --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/hillburmish_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --learning_rate=0.001 --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --logdir /tmp/logdir/
 ```
 
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/hillburmish_test.tfrecords --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/hillburmish_test.tfrecords --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00038142`.

--- a/systems/mockingbird-n2/surprise/hillburmish/README.md
+++ b/systems/mockingbird-n2/surprise/hillburmish/README.md
@@ -1,10 +1,18 @@
+# `hillburmish`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group hillburmish --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
+## Training
+
 ```shell
 python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/hillburmish_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --learning_rate=0.001 --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --logdir /tmp/logdir/
 ```
+
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/hillburmish_test.tfrecords --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --batch_size 1

--- a/systems/mockingbird-n2/surprise/hillburmish/README.md
+++ b/systems/mockingbird-n2/surprise/hillburmish/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group hillburmish --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group hillburmish --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ```shell
-python neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/hillburmish_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --learning_rate=0.001 --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/hillburmish_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/hillburmish_test.tfrecords --learning_rate=0.001 --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/hillburmish_test.tfrecords --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/hillburmish_test.tfrecords --input_symbols /tmp/tmp/hillburmish.syms --output_symbols /tmp/tmp/hillburmish.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=8 --max_pronunciation_len=7 --max_spelling_len=16 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/kesslersignificance/README.md
+++ b/systems/mockingbird-n2/surprise/kesslersignificance/README.md
@@ -9,13 +9,13 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/kesslersignificance_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/kesslersignificance.tfrecords --learning_rate=0.001 --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/kesslersignificance_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/kesslersignificance.tfrecords --learning_rate=0.001 --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --logdir /tmp/logdir/
 ```
 
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00025947`.

--- a/systems/mockingbird-n2/surprise/kesslersignificance/README.md
+++ b/systems/mockingbird-n2/surprise/kesslersignificance/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group kesslersignificance --lang all --pairwise_algo lingpy --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group kesslersignificance --lang all --pairwise_algo lingpy --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ## Training

--- a/systems/mockingbird-n2/surprise/kesslersignificance/README.md
+++ b/systems/mockingbird-n2/surprise/kesslersignificance/README.md
@@ -17,3 +17,5 @@ python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_m
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00025947`.

--- a/systems/mockingbird-n2/surprise/kesslersignificance/README.md
+++ b/systems/mockingbird-n2/surprise/kesslersignificance/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group kesslersignificance --lang all --pairwise_algo lingpy --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group kesslersignificance --lang all --pairwise_algo lingpy --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ```shell
-python neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/kesslersignificance_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/kesslersignificance.tfrecords --learning_rate=0.001 --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/kesslersignificance_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/kesslersignificance.tfrecords --learning_rate=0.001 --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/kesslersignificance/README.md
+++ b/systems/mockingbird-n2/surprise/kesslersignificance/README.md
@@ -1,10 +1,18 @@
+# `kesslersignificance`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group kesslersignificance --lang all --pairwise_algo lingpy --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
+## Training
+
 ```shell
 python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/kesslersignificance_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/kesslersignificance.tfrecords --learning_rate=0.001 --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --logdir /tmp/logdir/
 ```
+
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/kesslersignificance_test.tfrecords --input_symbols /tmp/tmp/kesslersignificance.syms --output_symbols /tmp/tmp/kesslersignificance.syms --ckpt /tmp/logdir/train --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=4 --max_pronunciation_len=11 --max_spelling_len=9 --batch_size 1

--- a/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
+++ b/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group luangthongkumkaren --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group luangthongkumkaren --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ```shell
-python neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/luangthongkumkaren_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/luangthongkumkaren_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --ckpt /usr/local/google/sweet/sigtyp2022/luangthongkumkaren/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --ckpt /usr/local/google/sweet/sigtyp2022/luangthongkumkaren/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
+++ b/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
@@ -1,10 +1,18 @@
+# `luangthongkumkaren`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group luangthongkumkaren --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
+## Training
+
 ```shell
 python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/luangthongkumkaren_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --logdir /tmp/logdir/
 ```
+
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --ckpt /usr/local/google/sweet/sigtyp2022/luangthongkumkaren/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --batch_size 1

--- a/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
+++ b/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group luangthongkumkaren --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group luangthongkumkaren --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ## Training

--- a/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
+++ b/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
@@ -9,13 +9,13 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/luangthongkumkaren_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/luangthongkumkaren_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --learning_rate=0.001 --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --logdir /tmp/logdir/
 ```
 
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --ckpt /usr/local/google/sweet/sigtyp2022/luangthongkumkaren/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --ckpt /usr/local/google/sweet/sigtyp2022/luangthongkumkaren/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00074519`.

--- a/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
+++ b/systems/mockingbird-n2/surprise/luangthongkumkaren/README.md
@@ -17,3 +17,5 @@ python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_m
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/luangthongkumkaren_test.tfrecords --input_symbols /tmp/tmp/luangthongkumkaren.syms --output_symbols /tmp/tmp/luangthongkumkaren.syms --ckpt /usr/local/google/sweet/sigtyp2022/luangthongkumkaren/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=7 --max_pronunciation_len=8 --max_spelling_len=12 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00074519`.

--- a/systems/mockingbird-n2/surprise/wangbai/README.md
+++ b/systems/mockingbird-n2/surprise/wangbai/README.md
@@ -3,7 +3,7 @@
 ## Data generation
 
 ```shell
-python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group wangbai --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group wangbai --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 ## Training
 

--- a/systems/mockingbird-n2/surprise/wangbai/README.md
+++ b/systems/mockingbird-n2/surprise/wangbai/README.md
@@ -1,11 +1,11 @@
 ```shell
-python neighborhood/data/create_neighborhood.py --output_dir /tmp/tmp --max_rand_len 10 --language_group wangbai --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
+python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group wangbai --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
 
 ```shell
-python neighborhood/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/wangbai_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/wangbai_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --logdir /tmp/logdir/
 ```
 
 ```shell
-python neighborhood/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/wangbai_test.tfrecords --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --ckpt /tmp/logdir/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --batch_size 1
+python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/wangbai_test.tfrecords --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --ckpt /tmp/logdir/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --batch_size 1
 ```

--- a/systems/mockingbird-n2/surprise/wangbai/README.md
+++ b/systems/mockingbird-n2/surprise/wangbai/README.md
@@ -1,10 +1,17 @@
+# `wangbai`
+
+## Data generation
+
 ```shell
 python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 10 --language_group wangbai --lang all --pairwise_algo lingpy --random_target_algo markov --logtostderr --task_data_dir ~/projects/ST2022/data-surprise  --num_duplicates 100
 ```
+## Training
 
 ```shell
 python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/wangbai_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --logdir /tmp/logdir/
 ```
+
+## Inference
 
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/wangbai_test.tfrecords --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --ckpt /tmp/logdir/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --batch_size 1

--- a/systems/mockingbird-n2/surprise/wangbai/README.md
+++ b/systems/mockingbird-n2/surprise/wangbai/README.md
@@ -16,3 +16,5 @@ python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_m
 ```shell
 python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/wangbai_test.tfrecords --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --ckpt /tmp/logdir/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --batch_size 1
 ```
+
+Latest model from `/tmp/logdir/train/ckpt-00076193`.

--- a/systems/mockingbird-n2/surprise/wangbai/README.md
+++ b/systems/mockingbird-n2/surprise/wangbai/README.md
@@ -8,13 +8,13 @@ python neighbors/data/create_neighbors.py --output_dir /tmp/tmp --max_rand_len 1
 ## Training
 
 ```shell
-python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighbors_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --feature_neighbors_train_path tfrecord:/tmp/tmp/wangbai_train.tfrecords --feature_neighbors_dev_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --feature_neighbors_test_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --logdir /tmp/logdir/
+python neighbors/model/trainer.py  --run_locally=cpu --model=feature_neighborhood_model_config.TransformerWithNeighborsTiny --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --feature_neighborhood_train_path tfrecord:/tmp/tmp/wangbai_train.tfrecords --feature_neighborhood_dev_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --feature_neighborhood_test_path tfrecord:/tmp/tmp/wangbai_test.tfrecords --learning_rate=0.001 --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --logdir /tmp/logdir/
 ```
 
 ## Inference
 
 ```shell
-python neighbors/model/decoder.py --feature_neighbors_test_path=tfrecord:/tmp/tmp/wangbai_test.tfrecords --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --ckpt /tmp/logdir/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --batch_size 1
+python neighbors/model/decoder.py --feature_neighborhood_test_path=tfrecord:/tmp/tmp/wangbai_test.tfrecords --input_symbols /tmp/tmp/wangbai.syms --output_symbols /tmp/tmp/wangbai.syms --ckpt /tmp/logdir/train/ --model=TransformerWithNeighborsTiny --decode_dir /tmp/tmp/decode_dir/ --split_output_on_space --max_neighbors=9 --max_pronunciation_len=6 --max_spelling_len=10 --batch_size 1
 ```
 
 Latest model from `/tmp/logdir/train/ckpt-00076193`.


### PR DESCRIPTION
For `mockingbird-n2` system:

1. Fix the command-line paths in documentation.
1. Introduce a bit of structure.
1. Document the exact checkpoints (number of training steps).

@ckirov, @rwsproat